### PR TITLE
Stop Incorrect Lock Setup

### DIFF
--- a/src/BaseGlobalEntry.sol
+++ b/src/BaseGlobalEntry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 

--- a/src/Constants.sol
+++ b/src/Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 library Constants {
     /// -------------------------------------------------

--- a/src/ReentrancyLockRef.sol
+++ b/src/ReentrancyLockRef.sol
@@ -1,0 +1,34 @@
+pragma solidity 0.8.20;
+
+import {GlobalReentrancyLock} from "@protocol/example/GlobalReentrancyLock.sol";
+
+/// @notice reference to the global reentrancy lock
+/// allows parent contracts to set the lock using their own logic
+contract ReentrancyLockRef {
+
+    /// @notice reference to the lock
+    GlobalReentrancyLock public lock;
+
+    /// @notice emitted when the lock is updated
+    event GlobalReentrancyLockUpdated(address indexed oldLock, address indexed newLock);
+
+    /// @notice construct the contract and set the lock
+    /// @param _lock the lock to set
+    constructor(GlobalReentrancyLock _lock) {
+        lock = _lock;
+    }
+
+    /// @notice global reentrancy lock modifier
+    /// @param toLock the lock level to lock to
+    modifier globalLock(uint8 toLock) {
+        lock.lock(toLock);
+        _;
+        lock.unlock(toLock - 1);
+    }
+
+    /// @notice set the lock to a new lock
+    /// @param _lock the new lock
+    function _setLock(GlobalReentrancyLock _lock) internal {
+        lock = _lock;
+    }
+}

--- a/src/example/ExampleGlobalReentrancyLock.sol
+++ b/src/example/ExampleGlobalReentrancyLock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import {AccessControlEnumerable} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import {BaseGlobalReentrancyLock} from "./../BaseGlobalReentrancyLock.sol";
@@ -17,8 +17,8 @@ contract ExampleGlobalReentrancyLock is BaseGlobalReentrancyLock, AccessControlE
     /// @notice emitted when governor makes use of emergency unlock
     event EmergencyUnlock();
 
-    /// maximum lock level of global reentrancy lock is 1.
-    constructor () BaseGlobalReentrancyLock(1) {
+    /// @param _maxLockLevel maximum lock level of global reentrancy lock
+    constructor (uint8 _maxLockLevel) BaseGlobalReentrancyLock(_maxLockLevel) {
         _grantRole(governor, msg.sender); /// sender is governor
         _grantRole(locker, msg.sender); /// sender is locker
         _setRoleAdmin(locker, governor); /// governor is admin of locker

--- a/src/example/ExampleSystem.sol
+++ b/src/example/ExampleSystem.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import {GlobalReentrancyLock} from "./GlobalReentrancyLock.sol";
 import {Constants} from "../Constants.sol";

--- a/src/example/GlobalReentrancyLock.sol
+++ b/src/example/GlobalReentrancyLock.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
-import {BaseGlobalReentrancyLock} from "./../BaseGlobalReentrancyLock.sol";
-import {Constants} from "../Constants.sol";
+import {BaseGlobalReentrancyLock} from "@protocol/BaseGlobalReentrancyLock.sol";
+import {Constants} from "@protocol/Constants.sol";
 
 /// @notice inpsired by the openzeppelin reentrancy guard smart contracts
 /// data container size has been changed.

--- a/src/example/HevmSymbolicTest.sol
+++ b/src/example/HevmSymbolicTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import {GlobalReentrancyLock} from "./GlobalReentrancyLock.sol";
 

--- a/src/example/IGlobalReentrancyLock.sol
+++ b/src/example/IGlobalReentrancyLock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 /// @notice inpsired by the openzeppelin reentrancy guard smart contracts
 /// data container size has been changed

--- a/test/helper/EphemeralLocker.sol
+++ b/test/helper/EphemeralLocker.sol
@@ -1,0 +1,14 @@
+pragma solidity 0.8.20;
+
+import {GlobalReentrancyLock} from "@protocol/example/GlobalReentrancyLock.sol";
+
+contract EphemeralLocker {
+    GlobalReentrancyLock public lock;
+
+    constructor(GlobalReentrancyLock _lock) {
+        lock = _lock;
+        uint8 currentLevel = lock.lockLevel();
+        lock.lock(currentLevel + 1);
+        selfdestruct(payable(msg.sender));
+    }
+}

--- a/test/helper/EphemeralUnlocker.sol
+++ b/test/helper/EphemeralUnlocker.sol
@@ -1,0 +1,14 @@
+pragma solidity 0.8.20;
+
+import {GlobalReentrancyLock} from "@protocol/example/GlobalReentrancyLock.sol";
+
+contract EphemeralUnlocker {
+    GlobalReentrancyLock public lock;
+
+    constructor(GlobalReentrancyLock _lock) {
+        lock = _lock;
+        uint8 currentLevel = lock.lockLevel();
+        lock.unlock(currentLevel - 1);
+        selfdestruct(payable(msg.sender));
+    }
+}

--- a/test/invariants/echidna/EchidnaTest.sol
+++ b/test/invariants/echidna/EchidnaTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import {GlobalReentrancyLock} from "../../../src/example/GlobalReentrancyLock.sol";
 import {Constants} from "./../../../src/Constants.sol";

--- a/test/invariants/echidna/EchidnaTestConfig.sol
+++ b/test/invariants/echidna/EchidnaTestConfig.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import {EchidnaTest, Constants} from "./EchidnaTest.sol";
 

--- a/test/mock/FootGunFailMock.sol
+++ b/test/mock/FootGunFailMock.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.20;
+
+import {ReentrancyLockRef} from "@protocol/ReentrancyLockRef.sol";
+import {GlobalReentrancyLock} from "@protocol/example/GlobalReentrancyLock.sol";
+import {BaseGlobalReentrancyLock} from "@protocol/BaseGlobalReentrancyLock.sol";
+
+contract FootGunFailMock is ReentrancyLockRef {
+    constructor (GlobalReentrancyLock _lock) ReentrancyLockRef(_lock) {}
+
+    function lockLevel1() external globalLock(1) {}
+
+    /// @notice this should fail because locker to level 2 should be a different
+    /// contract than level 1 to protect against reentrancy
+    function lockLevel2() external globalLock(2) {}
+}


### PR DESCRIPTION
Theoretically a developer could misconfigure a global reentrancy lock as seen in the `FootGunFailMock` contract by having a single contract lock up to 2 levels. This is invalid behavior and should not be allowed. This PR stops that behavior from happening by enforcing that the locker from level 2 up is not the same sender as the original locker. A developer could still misconfigure the contract by having lock levels 2 and 3 be set from the same contract, but that is not intended use as the maximum amount of lock levels should be 2.

This means that with expected contract and system configuration, it should be impossible to have write reentrancy in a system where this lock is applied correctly.